### PR TITLE
Redirect system path fix

### DIFF
--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 - Fix error 'WeakSet key must be an object' in fast-refresh for invalid exports like cpp host objects. ([#34026](https://github.com/expo/expo/pull/34026) by [@chrfalch](https://github.com/chrfalch))
 - Fix render store (unstable_headers) on native platforms. ([#33978](https://github.com/expo/expo/pull/33978) by [@EvanBacon](https://github.com/EvanBacon))
+- Fix `getStateFromPath` not using the native intent file if it contains a `redirectSystemPath` function. ([#34076](https://github.com/expo/expo/pull/34076)) by [@shllg](https://github.com/shllg)
+- Fix `redirectSystemPath` in `+native-intent.ts` not loading. ([#34076](https://github.com/expo/expo/pull/34076)) by [@shllg](https://github.com/shllg)
 
 ### 💡 Others
 

--- a/packages/expo-router/src/ExpoRoot.tsx
+++ b/packages/expo-router/src/ExpoRoot.tsx
@@ -114,7 +114,9 @@ function ContextNavigator({
     ? `${serverContext.location.pathname}${serverContext.location.search}`
     : undefined;
 
-  const store = useInitializeExpoRouter(context, {
+  // Load the router store and initialize it with the context, navigation ref and options.
+  // The store is instantiated in the global scope and might not be initialized yet.
+  const [storeInitialized, store] = useInitializeExpoRouter(context, {
     ...linking,
     serverUrl,
   });
@@ -138,7 +140,8 @@ function ContextNavigator({
 
   const Component = store.rootComponent;
 
-  return (
+  // Render the navigation container once the store is initialized.
+  return storeInitialized ? (
     <UpstreamNavigationContainer
       ref={store.navigationRef}
       initialState={store.initialState}
@@ -153,7 +156,7 @@ function ContextNavigator({
         </WrapperComponent>
       </ServerContext.Provider>
     </UpstreamNavigationContainer>
-  );
+  ) : null;
 }
 
 let onUnhandledAction: (action: NavigationAction) => void;

--- a/packages/expo-router/src/fork/getStateFromPath.ts
+++ b/packages/expo-router/src/fork/getStateFromPath.ts
@@ -6,6 +6,7 @@ import { findFocusedRoute } from './findFocusedRoute';
 import type { ExpoOptions, ExpoRouteConfig } from './getStateFromPath-forks';
 import * as expo from './getStateFromPath-forks';
 import { RouterStore } from '../global-state/router-store';
+import { NativeIntent } from '../types';
 
 export type Options<ParamList extends object> = ExpoOptions & {
   path?: string;
@@ -63,12 +64,15 @@ type ConfigResources = {
  *   }
  * )
  * ```
+ * @param this RouterStore instance
+ * @param nativeIntent NativeIntent file import which can contain a redirectSystemPath function
  * @param path Path string to parse and convert, e.g. /foo/bar?count=42.
  * @param options Extra options to fine-tune how to parse the path.
  */
 export function getStateFromPath<ParamList extends object>(
   // START FORK
   this: RouterStore | undefined | void,
+  nativeIntent: NativeIntent | undefined,
   // END FORK
   path: string,
   options?: Options<ParamList>
@@ -79,6 +83,14 @@ export function getStateFromPath<ParamList extends object>(
   );
 
   const screens = options?.screens;
+
+  // START FORK
+  // In case the nativeIntent contains a redirectSystemPath function, we use
+  // it handle the path before we start parsing it
+  if (nativeIntent && typeof nativeIntent.redirectSystemPath === 'function') {
+    path = nativeIntent.redirectSystemPath({ path, initial: false });
+  }
+  // END FORK
 
   // START FORK
   const expoPath = expo.getUrlWithReactNavigationConcessions(path);

--- a/packages/expo-router/src/global-state/routeInfo.ts
+++ b/packages/expo-router/src/global-state/routeInfo.ts
@@ -2,10 +2,12 @@ import * as queryString from 'query-string';
 
 import { State } from '../fork/getPathFromState';
 import { getStateFromPath } from '../fork/getStateFromPath';
+import { NativeIntent } from '../types';
 
-type Options = Parameters<typeof getStateFromPath>[1];
+type Options = Parameters<typeof getStateFromPath>[2];
 
 export function reconstructState(
+  nativeIntent: NativeIntent | undefined,
   state: State | undefined,
   getState: typeof getStateFromPath,
   options: Options
@@ -44,5 +46,5 @@ export function reconstructState(
     path += `?${query}`;
   }
 
-  return getState(path, options);
+  return getState(nativeIntent, path, options);
 }

--- a/packages/expo-router/src/types.ts
+++ b/packages/expo-router/src/types.ts
@@ -41,7 +41,9 @@ export type NativeIntent = {
    *
    * @see For usage information, see [Redirecting system paths](/router/advanced/native-intent/#redirectsystempath).
    */
-  redirectSystemPath?: (event: { path: string; initial: boolean }) => Promise<string> | string;
+  redirectSystemPath?: (event: { path: string; initial: boolean }) => string;
+  // redirectSystemPath?: (event: { path: string; initial: boolean }) => Promise<string> | string;
+
   /**
    * > **warning** Experimentally available in SDK 52.
    *


### PR DESCRIPTION
# Why

1. When loading the `+native-intent.ts` file via `context(nativeLinkingKey)`, it is possible that a promise is returned instead of the resolved module. As a consequence, `redirectSystemPath` will never be called preventing an URL rewrite.
2. `redirectSystemPath` is not called if the app is already open since `redirectSystemPath` was handled in `getInitialURL` but not in `getStateFromPath`. 

References:
* https://github.com/expo/expo/issues/33031
* https://github.com/expo/expo/issues/32725

# How

Solution for 1:

Await the module import for `require.context`. This also requires changes in `ExpoRoot` when loading the store. 

Solution for 2:

Extend `getStateFromPath` to take the `NativeIntent` and run the `redirectSystemPath` function if available.

# Test Plan

On an existing expo-router application, enable async routes in development:

```json
// app.json
{
  "expo": {
    "plugins": [
      [
        "expo-router",
        {
          "asyncRoutes": {
            "default": "development",
          }
        }
      ]
    ]
  }
}
```

Create some rewrites:

```typescript
// +native-intent.ts

export function redirectSystemPath({ path }: { path: string }) {
  if (path === 'myapp://some-route') return '/some-other-route'

  return path
}
```

Try to open the path:

```bash
npx uri-scheme open myapp:///some-route --ios
```

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
